### PR TITLE
Password reset

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,19 @@ class PasswordResetsController < ApplicationController
   def new
   end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "Email sent with password reset instructions"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "Email address not found"
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
   def edit
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -26,9 +26,9 @@ class PasswordResetsController < ApplicationController
     if params[:user][:password].empty?                  # Case (3)
       @user.errors.add(:password, "can't be empty")
       render 'edit', status: :unprocessable_entity
-    elsif @user.update(user_params)          # Case (4)
-      reset_session
+    elsif @user.update(user_params)          # Case (4)      
       log_in @user
+      @user.update_attribute(:reset_digest, nil)
       flash[:success] = "Password has been reset."
       redirect_to @user
     else

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,8 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update] # Case (1)
+
   def new
   end
 
@@ -17,4 +21,46 @@ class PasswordResetsController < ApplicationController
 
   def edit
   end
+
+  def update
+    if params[:user][:password].empty?                  # Case (3)
+      @user.errors.add(:password, "can't be empty")
+      render 'edit', status: :unprocessable_entity
+    elsif @user.update(user_params)          # Case (4)
+      reset_session
+      log_in @user
+      flash[:success] = "Password has been reset."
+      redirect_to @user
+    else
+      render 'edit', status: :unprocessable_entity       # Case (2)
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
+    # Before filters
+
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    # Confirms a valid user.
+    def valid_user
+      unless (@user && @user.activated? &&
+              @user.authenticated?(:reset, params[:id]))
+        redirect_to root_url
+      end   
+    end
+
+    # Checks expiration of reset token.
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "Password reset has expired."
+        redirect_to new_password_reset_url
+      end
+    end    
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,8 +18,9 @@ class UserMailer < ApplicationMailer
   #   en.user_mailer.password_reset.subject
   #
   def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+    # @greeting = "Hi"
+    # mail to: "to@example.org"
+    @user = user
+    mail to: user.email, subject: "Password reset"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   # before_save { self.email = email.downcase }
@@ -65,6 +65,18 @@ class User < ApplicationRecord
   # Sends activation email.
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # Sets the password reset attributes.
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_attribute(:reset_digest,  User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
+  end
+
+  # Sends password reset email.
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,21 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, "Reset password") %>
+<h1>Reset password</h1>
+
+<div class='row'>
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @user, url:
+        password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages' %>
+      <%= hidden_field_tag :email, @user.email %>
+      
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %> 
+      
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form- 
+            control' %>
+      
+      <%= f.submit "Update password", class: "btn btn-primary" %> 
+    <% end %>
+  </div> 
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,12 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<% provide :title, "Forgot password" %>
+<h1>Forgot password</h1>
+
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <%= form_with(url: password_resets_path, scope: :password_reset) do |f| %>
+            <%= f.label :email %>
+            <%= f.email_field :email, class: "form-control" %>
+            <%= f.submit "Submit", class: "btn btn-primary" %>
+        <% end %>
+    </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,10 +4,12 @@
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
         <%= form_with(url: login_path, scope: :session) do |f| %>
+        
             <%= f.label :email %>
             <%= f.email_field :email, class: "form-control" %>
 
             <%= f.label :password %>
+            <%= link_to "(Forgot password?)", new_password_reset_path %>
             <%= f.password_field :password, class: "form-control" %>
 
             <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,16 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p> 
+    To reset your password click the link below:
+</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token, email: @user.email) %>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+    This link will expire in two hours.
+</p>
+
+<p>
+    If you did not request your password to be reset, please ignore this email and
+    your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  # get 'password_resets/new'
+  # get 'password_resets/edit'
   # get 'users/new'
   # get 'static_pages/home'
   
@@ -15,4 +17,5 @@ Rails.application.routes.draw do
 
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets,     only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20221207150014_add_reset_to_users.rb
+++ b/db/migrate/20221207150014_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_04_133151) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_07_150014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_04_133151) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class PasswordResets < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    ActionMailer::Base.deliveries.clear 
+  end
+end
+
+class ForgotPasswordFormTest < PasswordResets
+
+  test "password reset path" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    assert_select 'input[name=?]', 'password_reset[email]' 
+  end
+  test "reset path with invalid email" do
+    post password_resets_path, params: { password_reset: { email: 
+    "" } }
+    assert_response :unprocessable_entity
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+  end 
+end
+  
+class PasswordResetForm < PasswordResets
+  def setup
+    super
+    @user = users(:michael) 
+    post password_resets_path,
+    params: { password_reset: { email: @user.email } } 
+    @reset_user = assigns(:user)
+  end 
+end
+
+class PasswordFormTest < PasswordResetForm
+  test "reset with valid email" do
+    assert_not_equal @user.reset_digest, @reset_user.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+  end
+  test "reset with wrong email" do
+    get edit_password_reset_path(@reset_user.reset_token, email: 
+    "")
+    assert_redirected_to root_url
+  end
+  test "reset with inactive user" do 
+    @reset_user.toggle!(:activated)
+    get edit_password_reset_path(@reset_user.reset_token,
+    email: @reset_user.email)
+    assert_redirected_to root_url
+  end
+  test "reset with right email but wrong token" do 
+    get edit_password_reset_path('wrong token', email:
+      @reset_user.email)
+    assert_redirected_to root_url
+  end
+  test "reset with right email and right token" do
+    get edit_password_reset_path(@reset_user.reset_token,
+    email: @reset_user.email)
+    assert_template 'password_resets/edit'
+    assert_select "input[name=email][type=hidden][value=?]", 
+    @reset_user.email
+  end 
+end
+
+class PasswordUpdateTest < PasswordResetForm
+  test "update with invalid password and confirmation" do 
+    patch password_reset_path(@reset_user.reset_token),
+    params: { email: @reset_user.email,
+    user: { password:              "foobaz", 
+    password_confirmation: "barquux" } }
+    assert_select 'div#error_explanation' 
+  end
+  test "update with empty password" do
+    patch password_reset_path(@reset_user.reset_token), 
+    params: { email: @reset_user.email,
+    user: { password: "",
+    password_confirmation: "" } }
+    assert_select 'div#error_explanation' 
+  end
+  test "update with valid password and confirmation" do
+    patch password_reset_path(@reset_user.reset_token), 
+    params: { email: @reset_user.email,
+    user: { password:              "foobaz", 
+    password_confirmation: "foobaz" } }
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to @reset_user 
+  end
+end
+

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
-
 end


### PR DESCRIPTION
> ## In this branch
---

• Like sessions and account activations, password resets can be modeled as a resource despite not being Active Record objects.
• Rails can generate Action Mailer actions and views to send email.
• Action Mailer supports both plain-text and HTML mail.
• As with ordinary actions and views, instance variables defined in mailer actions are available in mailer views.
• Password resets use a generated token to create a unique URL for resetting passwords.
• Password resets use a hashed reset digest to securely identify valid reset requests.
• Both mailer tests and integration tests are useful for verifying the behavior of the User mailer.